### PR TITLE
fix: createDocument return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## Version 4.3.1 - 2021-06-17
+
+- Fixed return type of createDocument
+
 ## Version 4.3.0 - 2021-06-10
 
 - Added getOrganization

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -25,6 +25,7 @@ import {
   FieldConfig,
   LasDocument,
   LasDocumentList,
+  LasDocumentWithoutContent,
   ListAppClientsOptions,
   ListAssetsOptions,
   ListBatchesOptions,
@@ -166,7 +167,7 @@ export class Client {
     content: string | Buffer,
     contentType: ContentType,
     options?: CreateDocumentOptions,
-  ): Promise<LasDocument> {
+  ): Promise<LasDocumentWithoutContent> {
     const encodedContent = typeof content === 'string' ? content : Buffer.from(content).toString('base64');
     let body = {
       content: encodedContent,
@@ -177,7 +178,7 @@ export class Client {
       body = { ...body, ...options };
     }
 
-    return this.makePostRequest<LasDocument>('/documents', body);
+    return this.makePostRequest<LasDocumentWithoutContent>('/documents', body);
   }
 
   /**


### PR DESCRIPTION
It was incorrectly showing that content would be returned