### PR TITLE
Version 10.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog 
 
+## Version 10.0.0 - 2022-09-13
+
+- Fix GET and DELETE requests getting `?` appended to URLs, even without any search parameters present.
+- Remove deprecated `Field` types
+- Add new `Field` type `numeric`
+- Add `contentMD5` to `LasDocument`
+- Add `dataScientistAssistance` to `Training`
+- Add `retentionInDays` to `DataBundle`
+- Add `contentMD5`, `createdBy`, `createdTime`, `description`, `name`, `updatedBy`, `updatedTime` to `Asset`
+
 ## Version 9.1.5 - 2022-06-27
 
 - Fix typo in Training type declaration; `evalution` -> `evaluation`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Version 10.0.0 - 2022-09-13
 
 - Fix GET and DELETE requests getting `?` appended to URLs, even without any search parameters present.
+- Fix `createdTime`, `description`, `name`, and `updatedTime` in `Dataset` to be nullable.
 - Remove deprecated `Field` types
 - Add new `Field` type `numeric`
 - Add `contentMD5` to `LasDocument`

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "9.1.5",
+  "version": "10.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "9.1.5",
+  "version": "10.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/src/client.spec.ts
+++ b/packages/las-sdk-core/src/client.spec.ts
@@ -856,8 +856,8 @@ describe('Models', () => {
     test.each<[FieldConfig, CreateModelOptions | undefined]>([
       [
         {
-          total_amount: { type: 'amount', maxLength: 20, description: 'Total Amount' },
-          purchase_date: { type: 'date', maxLength: 10, description: 'Purchase Date' },
+          total_amount: { type: 'amount', description: 'Total Amount' },
+          purchase_date: { type: 'date', description: 'Purchase Date' },
           department: { type: 'enum', enum: ['finance', 'warehouse'] },
         },
         {
@@ -868,9 +868,9 @@ describe('Models', () => {
       ],
       [
         {
-          total_amount: { type: 'amount', maxLength: 20, description: 'Total Amount' },
-          purchase_date: { type: 'date', maxLength: 10, description: 'Purchase Date' },
-          supplier_id: { type: 'alphanum', maxLength: 25, description: 'Supplier ID' },
+          total_amount: { type: 'amount', description: 'Total Amount' },
+          purchase_date: { type: 'date', description: 'Purchase Date' },
+          supplier_id: { type: 'string', description: 'Supplier ID' },
         },
         undefined,
       ],
@@ -914,27 +914,23 @@ describe('Models', () => {
         createModelId(),
         {
           fieldConfig: {
-            total_amount: { type: 'amount', maxLength: 20, description: 'Total Amount' },
-            purchase_date: { type: 'date', maxLength: 10, description: 'Purchase Date' },
-            supplier_id: { type: 'alphanum', maxLength: 25, description: 'Supplier ID' },
+            total_amount: { type: 'amount', description: 'Total Amount' },
+            purchase_date: { type: 'date', description: 'Purchase Date' },
+            supplier_id: { type: 'string', description: 'Supplier ID' },
             due_date: {
               description: 'Due date of invoice.',
-              maxLength: 10,
               type: 'date',
             },
             lines: {
               description: 'line',
-              maxLength: 4,
               type: 'lines',
               fields: {
                 name: {
                   description: 'name',
-                  maxLength: 10,
                   type: 'string',
                 },
                 price: {
                   description: 'price',
-                  maxLength: 10,
                   type: 'string',
                 },
               },

--- a/packages/las-sdk-core/src/types.ts
+++ b/packages/las-sdk-core/src/types.ts
@@ -19,6 +19,7 @@ export type GroundTruthItem = {
 export type LasDocument = {
   consentId?: string;
   content: string;
+  contentMD5: string | null;
   contentType: ContentType;
   datasetId?: string;
   name: string | null;
@@ -381,6 +382,7 @@ export type DataBundle = {
   description: string | null;
   modelId: string;
   name: string | null;
+  retentionInDays: number;
   status: 'succeeded' | 'running' | 'failed';
   summary: Record<string, any>;
   updatedBy: string | null;
@@ -561,6 +563,13 @@ export type DeleteAppClientOptions = RequestConfig;
 export type Asset = {
   assetId: string;
   content: string;
+  contentMD5: string | null;
+  createdBy: string | null;
+  createdTime: string | null;
+  description: string | null;
+  name: string | null;
+  updatedBy: string | null;
+  updatedTime: string | null;
 };
 
 export type AssetWithoutContent = Omit<Asset, 'content'>;
@@ -581,19 +590,7 @@ export type Field = {
   fields?: FieldConfig;
   enum?: Array<string>;
   maxLength?: number;
-  type:
-    | 'all'
-    | 'alphanum'
-    | 'alphanumext'
-    | 'amount'
-    | 'date'
-    | 'digits'
-    | 'enum'
-    | 'letter'
-    | 'lines'
-    | 'number'
-    | 'phone'
-    | 'string';
+  type: 'amount' | 'date' | 'digits' | 'enum' | 'lines' | 'numeric' | 'string';
 };
 
 export type FieldConfig = Record<string, Field>;
@@ -652,17 +649,18 @@ export type Training = {
   createdBy: string | null;
   createdTime: string | null;
   dataBundleIds: Array<string>;
+  dataScientistAssistance: boolean;
   description: string | null;
   evaluation: Record<string, any>;
   gpuHours: number | null;
   instanceType: TrainingInstanceType;
+  metadata: Record<string, JSONValue> | null;
   modelId: string;
   name: string | null;
   status: TrainingStatus;
   trainingId: string;
   updatedBy: string | null;
   updatedTime: string | null;
-  metadata: Record<string, JSONValue> | null;
 };
 
 export type TrainingList = {

--- a/packages/las-sdk-core/src/types.ts
+++ b/packages/las-sdk-core/src/types.ts
@@ -333,18 +333,18 @@ export type DeleteAssetOptions = RequestConfig;
 export type Dataset = {
   containsPersonallyIdentifiableInformation: boolean;
   createdBy: string | null;
-  createdTime: string;
+  createdTime: string | null;
   datasetId: string;
-  description: string;
+  description: string | null;
   groundTruthSummary: Record<string, number>;
-  name: string;
+  metadata: Record<string, JSONValue> | null;
+  name: string | null;
   numberOfDocuments: number;
   retentionInDays: number;
   storageLocation: 'EU';
   updatedBy: string | null;
-  updatedTime: string;
+  updatedTime: string | null;
   version: number;
-  metadata: Record<string, JSONValue> | null;
 };
 
 export type CreateDatasetOptions = RequestConfig & {

--- a/packages/las-sdk-core/src/utils.spec.ts
+++ b/packages/las-sdk-core/src/utils.spec.ts
@@ -9,8 +9,9 @@ describe('buildUrl', () => {
     [{ key: 'value1 value2 value3' }, 'http://localhost/', 'http://localhost/?key=value1+value2+value3'],
     [{ key: 'value1+value2' }, 'http://localhost/', 'http://localhost/?key=value1%2Bvalue2'],
     [{ key: '+asdf/qwerty=' }, 'http://localhost/', 'http://localhost/?key=%2Basdf%2Fqwerty%3D'],
-    [{ key: undefined }, 'http://localhost/', 'http://localhost/?'],
-    [{ key1: undefined, key2: undefined }, 'http://localhost/', 'http://localhost/?'],
+    [{ key: undefined }, 'http://localhost/', 'http://localhost/'],
+    [{ key1: undefined, key2: undefined }, 'http://localhost/', 'http://localhost/'],
+    [{}, 'http://localhost/', 'http://localhost/'],
   ])('builds correct url for: %o', async (params, url, expected) => {
     expect(buildURL(url, params)).toBe(expected);
   });

--- a/packages/las-sdk-core/src/utils.ts
+++ b/packages/las-sdk-core/src/utils.ts
@@ -1,7 +1,7 @@
 export type BuildURLParams = Record<string, undefined | string | Array<string> | number>;
 
 export function buildURL(url: string, params?: BuildURLParams): string {
-  if (!params) {
+  if (!params || Object.keys(params).length === 0) {
     return url;
   }
 
@@ -28,6 +28,11 @@ export function buildURL(url: string, params?: BuildURLParams): string {
       });
     }
   });
+
+  // Input contained keys, but all were undefined
+  if (searchParams.entries().next().done) {
+    return url;
+  }
 
   return `${url}?${searchParams}`;
 }

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "9.1.5",
+  "version": "10.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",


### PR DESCRIPTION
- Fix GET and DELETE requests getting `?` appended to URLs, even without any search parameters present.
- Fix `createdTime`, `description`, `name`, and `updatedTime` in `Dataset` to be nullable.
- Remove deprecated `Field` types
- Add new `Field` type `numeric`
- Add `contentMD5` to `LasDocument`
- Add `dataScientistAssistance` to `Training`
- Add `retentionInDays` to `DataBundle`
- Add `contentMD5`, `createdBy`, `createdTime`, `description`, `name`, `updatedBy`, `updatedTime` to `Asset`