### PR TITLE
feat: file server support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.1 - 2023-08-09
+## Version 13.0.0-beta.2 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.2 - 2023-08-09
+## Version 13.0.0-beta.3 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.4 - 2023-08-09
+## Version 13.0.0-beta.5 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version 13.0.0-beta.1 - 2023-08-09
 
-- BREAKING: `createDocument` now takes in Buffer/Uint8Array
+- BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 
 ## Version 12.0.1-rc.4 - 2023-06-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.3 - 2023-08-09
+## Version 13.0.0-beta.4 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 12.0.1-rc.3 - 2023-06-28
+## Version 12.0.1-rc.4 - 2023-06-28
 
 - Fix `getDocument` method to be compatible with new API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog 
 
+## Version 13.0.0-beta.1 - 2023-08-09
+
+- BREAKING: `createDocument` now takes in Buffer/Uint8Array
+
 ## Version 12.0.1-rc.4 - 2023-06-28
 
 - Fix `getDocument` method to be compatible with new API changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.7 - 2023-08-09
+## Version 13.0.0-beta.8 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 12.0.1-rc.2 - 2023-06-28
+## Version 12.0.1-rc.3 - 2023-06-28
 
 - Fix `getDocument` method to be compatible with new API changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog 
 
-## Version 13.0.0-beta.8 - 2023-08-09
+## Version 13.0.0 - 2023-08-10
 
+Update to make use of new file server feature for `LasDocument`:
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
-
-## Version 12.0.1-rc.4 - 2023-06-28
-
 - Fix `getDocument` method to be compatible with new API changes
 
 ## Version 12.0.0 - 2023-06-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.6 - 2023-08-09
+## Version 13.0.0-beta.7 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog 
 
-## Version 13.0.0-beta.5 - 2023-08-09
+## Version 13.0.0-beta.6 - 2023-08-09
 
 - BREAKING: `createDocument` now takes in Buffer/ArrayBuffer/Uint8Array
 

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.8",
+  "version": "13.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.6",
+  "version": "13.0.0-beta.7",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "12.0.1-rc.3",
+  "version": "12.0.1-rc.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.4",
+  "version": "13.0.0-beta.5",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.3",
+  "version": "13.0.0-beta.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "12.0.1-rc.4",
+  "version": "12.0.1-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.5",
+  "version": "13.0.0-beta.6",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "12.0.1-beta.1",
+  "version": "13.0.0-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "12.0.1-rc.2",
+  "version": "12.0.1-rc.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.7",
+  "version": "13.0.0-beta.8",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.0.0-beta.2",
+  "version": "13.0.0-beta.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-browser/src/credentials.ts
+++ b/packages/las-sdk-browser/src/credentials.ts
@@ -130,11 +130,7 @@ export class AuthorizationCodeCredentials extends Credentials {
 
       this.postToTokenEndpoint(params)
         .then((newToken) => {
-          resolve(new Token(
-            newToken.accessToken,
-            newToken.expiration,
-            newToken.refreshToken || token.refreshToken,
-          ));
+          resolve(new Token(newToken.accessToken, newToken.expiration, newToken.refreshToken || token.refreshToken));
         })
         .catch((error) => {
           console.debug(`Error getting accessToken using refreshToken: ${error.message}`);

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "12.0.1-rc.4",
+  "version": "12.0.1-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.6",
+  "version": "13.0.0-beta.7",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "12.0.1-rc.2",
+  "version": "12.0.1-rc.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.7",
+  "version": "13.0.0-beta.8",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.4",
+  "version": "13.0.0-beta.5",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.8",
+  "version": "13.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.2",
+  "version": "13.0.0-beta.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "12.0.1-beta.1",
+  "version": "13.0.0-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.5",
+  "version": "13.0.0-beta.6",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.0.0-beta.3",
+  "version": "13.0.0-beta.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "12.0.1-rc.3",
+  "version": "12.0.1-rc.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",
@@ -26,6 +26,7 @@
   "dependencies": {
     "axios": "^0.24.0",
     "buffer": "^6.0.3",
+    "js-base64": "^3.7.5",
     "node-abort-controller": "^3.0.1"
   },
   "devDependencies": {

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -217,7 +217,6 @@ export class Client {
     options?: CreateDocumentOptions,
   ): Promise<LasDocumentWithoutContent> {
     let body = {
-      content: null,
       contentType,
     };
 

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -212,7 +212,7 @@ export class Client {
    * @returns Document response from REST API
    */
   async createDocument(
-    content: Buffer,
+    content: ArrayBuffer | Uint8Array | Buffer,
     contentType: ContentType,
     options?: CreateDocumentOptions,
   ): Promise<LasDocumentWithoutContent> {
@@ -226,7 +226,8 @@ export class Client {
     }
 
     const lasDoc = await this.makePostRequest<LasDocumentWithoutContent>('/documents', body);
-    await this.makeFileServerPutRequest(lasDoc.fileUrl, content);
+    const asBuffer = Buffer.from(content);
+    await this.makeFileServerPutRequest(lasDoc.fileUrl, asBuffer);
     return lasDoc;
   }
 

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1217,7 +1217,6 @@ export class Client {
     options: any = {},
   ): Promise<T> {
     const headers = await this.getAuthorizationHeaders();
-    headers['Content-Type'] = 'application/octet-stream';
     const { requestConfig, data } = options;
     let config: AxiosRequestConfig = { headers };
     if (requestConfig) {

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1191,7 +1191,7 @@ export class Client {
   }
 
   async makeFileServerPutRequest<T>(fileUrl: string, content: Buffer, options: any = {}): Promise<T> {
-    options.body = content.buffer;
+    options.body = content;
     return this.makeAuthorizedFileServerBodyRequest<T>(axios.put, fileUrl, options);
   }
 
@@ -1217,6 +1217,7 @@ export class Client {
     options: any = {},
   ): Promise<T> {
     const headers = await this.getAuthorizationHeaders();
+    headers['Content-Type'] = 'application/octet-stream';
     const { requestConfig, ...body } = options;
     let config: AxiosRequestConfig = { headers };
     if (requestConfig) {

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1192,7 +1192,7 @@ export class Client {
 
   async makeFileServerPutRequest<T>(fileUrl: string, content: Buffer, options: any = {}): Promise<T> {
     options.data = content;
-    return this.makeAuthorizedFileServerRequest<T>(axios.put, fileUrl, options);
+    return this.makeAuthorizedFileServerBodyRequest<T>(axios.put, fileUrl, options);
   }
 
   private async makeAuthorizedFileServerRequest<T>(
@@ -1207,6 +1207,24 @@ export class Client {
     }
 
     const result = await axiosFn<T>(fileUrl, config);
+
+    return result.data;
+  }
+
+  private async makeAuthorizedFileServerBodyRequest<T>(
+    axiosFn: AxiosFn,
+    fileUrl: string,
+    options: any = {},
+  ): Promise<T> {
+    const headers = await this.getAuthorizationHeaders();
+    headers['Content-Type'] = 'application/octet-stream';
+    const { requestConfig, data } = options;
+    let config: AxiosRequestConfig = { headers };
+    if (requestConfig) {
+      config = { ...config, ...requestConfig };
+    }
+
+    const result = await axiosFn<T>(fileUrl, data, config);
 
     return result.data;
   }

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -227,6 +227,9 @@ export class Client {
     const lasDoc = await this.makePostRequest<LasDocumentWithoutContent>('/documents', body);
     const asBuffer = Buffer.from(content);
     await this.makeFileServerPutRequest(lasDoc.fileUrl, asBuffer);
+    // At this point, contentType = null
+    // Knowing the fileserver PUT request succeeded, we manually override this
+    lasDoc.contentType = contentType;
     return lasDoc;
   }
 

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1191,7 +1191,7 @@ export class Client {
   }
 
   async makeFileServerPutRequest<T>(fileUrl: string, content: Buffer, options: any = {}): Promise<T> {
-    options.body = content;
+    options.body = content.buffer;
     return this.makeAuthorizedFileServerBodyRequest<T>(axios.put, fileUrl, options);
   }
 

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -994,7 +994,6 @@ export class Client {
    * @returns Models response from the REST API
    */
   async listModels(options?: ListModelsOptions): Promise<ModelList> {
-    console.log('Using link!');
     return this.makeGetRequest<ModelList>('/models', options);
   }
 

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1181,8 +1181,12 @@ export class Client {
 
   async makeFileServerGetRequest(fileUrl: string, options: any = {}): Promise<ArrayBuffer> {
     const { requestConfig, ...query } = options;
-    const constructedRequestConfig = { responseType: 'arraybuffer', ...requestConfig }
-    return this.makeAuthorizedFileServerRequest<ArrayBuffer>(axios.get, buildURL(fileUrl, query), constructedRequestConfig);
+    const constructedRequestConfig = { responseType: 'arraybuffer', ...requestConfig };
+    return this.makeAuthorizedFileServerRequest<ArrayBuffer>(
+      axios.get,
+      buildURL(fileUrl, query),
+      constructedRequestConfig,
+    );
   }
 
   private async makeAuthorizedFileServerRequest<T>(

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -1191,8 +1191,8 @@ export class Client {
   }
 
   async makeFileServerPutRequest<T>(fileUrl: string, content: Buffer, options: any = {}): Promise<T> {
-    options.body = content;
-    return this.makeAuthorizedFileServerBodyRequest<T>(axios.put, fileUrl, options);
+    options.data = content;
+    return this.makeAuthorizedFileServerRequest<T>(axios.put, fileUrl, options);
   }
 
   private async makeAuthorizedFileServerRequest<T>(
@@ -1207,24 +1207,6 @@ export class Client {
     }
 
     const result = await axiosFn<T>(fileUrl, config);
-
-    return result.data;
-  }
-
-  private async makeAuthorizedFileServerBodyRequest<T>(
-    axiosFn: AxiosFn,
-    fileUrl: string,
-    options: any = {},
-  ): Promise<T> {
-    const headers = await this.getAuthorizationHeaders();
-    headers['Content-Type'] = 'application/octet-stream';
-    const { requestConfig, ...body } = options;
-    let config: AxiosRequestConfig = { headers };
-    if (requestConfig) {
-      config = { ...config, ...requestConfig };
-    }
-
-    const result = await axiosFn<T>(fileUrl, body, config);
 
     return result.data;
   }

--- a/packages/las-sdk-core/src/types/document.ts
+++ b/packages/las-sdk-core/src/types/document.ts
@@ -10,7 +10,7 @@ export type GroundTruthItem = {
 
 export type LasDocument = {
   consentId?: string;
-  content: string;
+  content: string | null;
   contentMD5: string | null;
   contentType: ContentType;
   createdBy: string | null;
@@ -19,6 +19,7 @@ export type LasDocument = {
   description: string | null;
   documentId: string;
   groundTruth?: GroundTruth;
+  fileUrl: string | null;
   metadata: Record<string, unknown> | null;
   name: string | null;
   retentionInDays: number;

--- a/packages/las-sdk-core/src/utils.ts
+++ b/packages/las-sdk-core/src/utils.ts
@@ -1,3 +1,5 @@
+import { Base64 } from 'js-base64';
+
 export type BuildURLParams = Record<string, undefined | string | Array<string> | number>;
 
 export function buildURL(url: string, params?: BuildURLParams): string {
@@ -42,11 +44,7 @@ export function wait(ms: number): Promise<void> {
 }
 
 export function arrayBufferToBase64(buffer: ArrayBuffer) {
-  let binary = '';
   const bytes = new Uint8Array(buffer);
-  const len = bytes.byteLength;
-  for (let i = 0; i < len; i++) {
-      binary += String.fromCharCode(bytes[i]);
-  }
-  return btoa(binary);
+  const contentAsB64 = Base64.fromUint8Array(bytes);
+  return contentAsB64;
 }

--- a/packages/las-sdk-core/src/utils.ts
+++ b/packages/las-sdk-core/src/utils.ts
@@ -40,3 +40,13 @@ export function buildURL(url: string, params?: BuildURLParams): string {
 export function wait(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+export function arrayBufferToBase64(buffer: ArrayBuffer) {
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  const len = bytes.byteLength;
+  for (let i = 0; i < len; i++) {
+      binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "12.0.1-rc.2",
+  "version": "12.0.1-rc.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.5",
+  "version": "13.0.0-beta.6",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "12.0.1-rc.3",
+  "version": "12.0.1-rc.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.4",
+  "version": "13.0.0-beta.5",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.7",
+  "version": "13.0.0-beta.8",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "12.0.1-beta.1",
+  "version": "13.0.0-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.1",
+  "version": "13.0.0-beta.2",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.3",
+  "version": "13.0.0-beta.4",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "12.0.1-rc.4",
+  "version": "12.0.1-beta.1",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.6",
+  "version": "13.0.0-beta.7",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.8",
+  "version": "13.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.0.0-beta.2",
+  "version": "13.0.0-beta.3",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,6 +82,9 @@ importers:
       buffer:
         specifier: ^6.0.3
         version: 6.0.3
+      js-base64:
+        specifier: ^3.7.5
+        version: 3.7.5
       node-abort-controller:
         specifier: ^3.0.1
         version: 3.0.1
@@ -2520,6 +2523,10 @@ packages:
       - ts-node
       - utf-8-validate
     dev: true
+
+  /js-base64@3.7.5:
+    resolution: {integrity: sha512-3MEt5DTINKqfScXKfJFrRbxkrnk2AxPWGBL/ycjz4dK8iqiSJ06UxD8jh8xuh6p10TX4t2+7FsBYVxxQbMg+qA==}
+    dev: false
 
   /js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}


### PR DESCRIPTION
Update to new major version, supporting new file server features.

Breaking change to `createDocument`, now taking in a Buffer/ArrayBuffer/UInt8Array instead of base64-encoded string
Backwards compatible change to `getDocument`, automatically fetching `fileUrl` if it exists and `content === null`, encoding the content to base64 and adding it to `content`