### PR TITLE
feat: API updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Update `Workflow` type with missing fields
 - Make some `Workflow` fields optional
 - Remove `avatar`, `email`, `name` from all `User`-related types
+- Add `status` to `User`
 
 ## Version 13.1.1 - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add optional `owner` query parameter to `listModels` method
 - Update `Workflow` type with missing fields
 - Make some `Workflow` fields optional
+- Remove `avatar`, `email`, `name` from all `User`-related types
 
 ## Version 13.1.1 - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog 
 
+## Version 14.0.0 - 2023-09-18
+
+- Remove `height` and `width` from all `Model`-related types
+- Add optional `owner` query parameter to `listModels` method
+
 ## Version 13.1.1 - 2023-08-24
 
 - Fix missing export of `Role`-related types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Make some `Workflow` fields optional
 - Remove `avatar`, `email`, `name` from all `User`-related types
 - Add `status` to `User`
+- Add optional `modelId` query parameter to `listPredictions` method
 
 ## Version 13.1.1 - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Remove `avatar`, `email`, `name` from all `User`-related types
 - Add `status` to `User`
 - Add optional `modelId` query parameter to `listPredictions` method
+- Add `getProfile` and `updateProfile` methods
 
 ## Version 13.1.1 - 2023-08-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - Remove `height` and `width` from all `Model`-related types
 - Add optional `owner` query parameter to `listModels` method
+- Update `Workflow` type with missing fields
+- Make some `Workflow` fields optional
 
 ## Version 13.1.1 - 2023-08-24
 

--- a/packages/las-sdk-browser/package.json
+++ b/packages/las-sdk-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-browser",
-  "version": "13.1.1",
+  "version": "14.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/package.json
+++ b/packages/las-sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-core",
-  "version": "13.1.1",
+  "version": "14.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",

--- a/packages/las-sdk-core/src/client.ts
+++ b/packages/las-sdk-core/src/client.ts
@@ -51,6 +51,7 @@ import type {
   GetLogOptions,
   GetModelOptions,
   GetOrganizationOptions,
+  GetProfileOptions,
   GetTransitionExecutionOptions,
   GetTransitionOptions,
   GetUserOptions,
@@ -87,6 +88,8 @@ import type {
   PostPredictions,
   PredictionList,
   PredictionResponse,
+  PrivateProfile,
+  PublicProfile,
   Secret,
   SecretList,
   Training,
@@ -104,6 +107,7 @@ import type {
   UpdateModelOptions,
   UpdateOrganizationOptions,
   UpdatePaymentMethodOptions,
+  UpdateProfileOptions,
   UpdateSecretOptions,
   UpdateTrainingOptions,
   UpdateTransitionExecution,
@@ -1151,6 +1155,28 @@ export class Client {
    */
   async getLog(logId: string, options?: GetLogOptions): Promise<Log> {
     return this.makeGetRequest<Log>(`/logs/${logId}`, options);
+  }
+
+  /**
+   * Get profile, calls the GET /profiles/{profileId} endpoint.
+   *
+   * @param profileId Id of the profile
+   * @param options Request options
+   * @returns Profile response from REST API
+   */
+  async getProfile(profileId: string, options?: GetProfileOptions): Promise<PublicProfile | PrivateProfile> {
+    return this.makeGetRequest<PublicProfile | PrivateProfile>(`/profiles/${profileId}`, options);
+  }
+
+  /**
+   * Updates a profile, calls the PATCH /profiles/{profileId} endpoint.
+   *
+   * @param profileId Id of the profile
+   * @param options Request options
+   * @returns Profile response from REST API
+   */
+  async updateProfile(profileId: string, options?: UpdateProfileOptions): Promise<PrivateProfile> {
+    return this.makePatchRequest<PrivateProfile>(`/profiles/${profileId}`, options);
   }
 
   /**

--- a/packages/las-sdk-core/src/types/model.ts
+++ b/packages/las-sdk-core/src/types/model.ts
@@ -9,9 +9,8 @@ export type PreprocessConfig = {
 
 export type Field = {
   description?: string;
-  fields?: FieldConfig;
   enum?: Array<string>;
-  maxLength?: number;
+  fields?: FieldConfig;
   type: 'amount' | 'date' | 'digits' | 'enum' | 'lines' | 'numeric' | 'string';
 };
 
@@ -19,12 +18,10 @@ export type FieldConfig = Record<string, Field>;
 
 export type CreateModelOptions = RequestConfig & {
   description?: string;
+  metadata?: Record<string, JSONValue> | null;
   name?: string;
-  width?: number;
-  height?: number;
   postprocessConfig?: PostprocessConfig;
   preprocessConfig?: PreprocessConfig;
-  metadata?: Record<string, JSONValue> | null;
 };
 
 export type GetModelOptions = RequestConfig;
@@ -32,12 +29,10 @@ export type GetModelOptions = RequestConfig;
 export type UpdateModelOptions = RequestConfig & {
   description?: string;
   fieldConfig?: FieldConfig;
-  height?: number;
+  metadata?: Record<string, JSONValue> | null;
   name?: string;
   postprocessConfig?: PostprocessConfig;
   preprocessConfig?: PreprocessConfig;
-  width?: number;
-  metadata?: Record<string, JSONValue> | null;
   trainingId?: string | null;
 };
 
@@ -48,7 +43,7 @@ export type Model = {
   createdTime: string | null;
   description: string | null;
   fieldConfig: FieldConfig | null;
-  height: number;
+  metadata: Record<string, JSONValue> | null;
   modelId: string;
   name: string | null;
   numberOfDataBundles: number;
@@ -60,11 +55,9 @@ export type Model = {
   trainingId: string | null;
   updatedBy: string | null;
   updatedTime: string | null;
-  width: number;
-  metadata: Record<string, JSONValue> | null;
 };
 
-export type ListModelsOptions = RequestConfig & PaginationOptions;
+export type ListModelsOptions = { owner?: Array<string> } & RequestConfig & PaginationOptions;
 
 export type ModelList = {
   models: Array<Model>;

--- a/packages/las-sdk-core/src/types/prediction.ts
+++ b/packages/las-sdk-core/src/types/prediction.ts
@@ -54,6 +54,7 @@ export type ListPredictionsOptions = RequestConfig &
   PaginationOptions & {
     order?: 'ascending' | 'descending';
     sortBy?: 'createdTime';
+    modelId?: string;
   };
 
 export type PredictionList = {

--- a/packages/las-sdk-core/src/types/profile.ts
+++ b/packages/las-sdk-core/src/types/profile.ts
@@ -1,3 +1,7 @@
+import { RequestConfig } from './common';
+
+export type GetProfileOptions = RequestConfig;
+
 export type PrivateProfile = {
   createdTime: string | null;
   email: string | null;
@@ -10,6 +14,14 @@ export type PrivateProfile = {
   picture: string | null;
   profileId: string;
   updatedTime: string | null;
+};
+
+export type UpdateProfileOptions = RequestConfig & {
+  givenName?: string | null;
+  familyName?: string | null;
+  locale?: string | null;
+  metadata?: Record<string, unknown> | null;
+  picture?: string | null;
 };
 
 export type PublicProfile = Pick<PrivateProfile, 'givenName' | 'familyName' | 'picture' | 'profileId'>;

--- a/packages/las-sdk-core/src/types/user.ts
+++ b/packages/las-sdk-core/src/types/user.ts
@@ -1,12 +1,9 @@
 import { JSONValue, PaginationOptions, RequestConfig } from './common';
 
 export type User = {
-  avatar: string | null;
   createdBy: string | null;
   createdTime: string | null;
-  email: string;
   metadata: Record<string, JSONValue> | null;
-  name: string | null;
   profileId: string | null;
   roleIds: Array<string>;
   updatedBy: string | null;
@@ -16,16 +13,12 @@ export type User = {
 
 export type CreateUserOptions = RequestConfig & {
   appClientId?: string;
-  avatar?: string;
   metadata?: Record<string, JSONValue> | null;
-  name?: string;
   roleIds?: Array<string>;
 };
 
 export type UpdateUserOptions = RequestConfig & {
-  avatar?: string | null;
   metadata?: Record<string, JSONValue> | null;
-  name?: string | null;
   roleIds?: Array<string>;
 };
 

--- a/packages/las-sdk-core/src/types/user.ts
+++ b/packages/las-sdk-core/src/types/user.ts
@@ -6,6 +6,7 @@ export type User = {
   metadata: Record<string, JSONValue> | null;
   profileId: string | null;
   roleIds: Array<string>;
+  status: 'inactive' | 'active' | 'invite_pending';
   updatedBy: string | null;
   updatedTime: string | null;
   userId: string;

--- a/packages/las-sdk-core/src/types/workflow.ts
+++ b/packages/las-sdk-core/src/types/workflow.ts
@@ -1,4 +1,4 @@
-import { PaginationOptions, RequestConfig } from './common';
+import { JSONValue, PaginationOptions, RequestConfig } from './common';
 
 export type WorkflowSpecification = {
   definition: object;
@@ -7,12 +7,17 @@ export type WorkflowSpecification = {
 };
 
 export type Workflow = {
-  name: string | null;
-  workflowId: string;
-  description: string | null;
-  numberOfRunningExecutions: number;
   completedConfig: WorkflowCompletedConfig;
+  createdBy: null | string;
+  createdTime: null | string;
+  description: string | null;
   errorConfig: WorkflowErrorConfig;
+  metadata: Record<string, JSONValue> | null;
+  name: string | null;
+  numberOfRunningExecutions: number;
+  updatedBy: null | string;
+  updatedTime: null | string;
+  workflowId: string;
 };
 
 export type WorkflowCompletedConfig = {
@@ -39,16 +44,19 @@ export type ListWorkflowExecutionsOptions = RequestConfig &
   };
 
 export type CreateWorkflowOptions = RequestConfig & {
+  completedConfig?: WorkflowCompletedConfig;
   description?: string | null;
   errorConfig?: WorkflowErrorConfig;
-  completedConfig?: WorkflowCompletedConfig;
+  metadata?: Record<string, JSONValue>;
+  name?: string | null;
 };
 
 export type UpdateWorkflowOptions = RequestConfig & {
-  name?: string | null;
+  completedConfig?: WorkflowCompletedConfig;
   description?: string | null;
   errorConfig?: WorkflowErrorConfig;
-  completedConfig?: WorkflowCompletedConfig;
+  metadata?: Record<string, JSONValue>;
+  name?: string | null;
 };
 
 export type GetWorkflowOptions = RequestConfig;
@@ -71,22 +79,22 @@ export type DeleteWorkflowExecution = RequestConfig;
 
 export type WorkflowExecution = {
   completedBy: Array<string>;
-  completedTaskLogId: string | null;
+  completedTaskLogId?: string | null;
   endTime: string | null;
-  events: Array<Record<any, any>>;
+  events?: Array<Record<any, any>>;
   executionId: string;
   input: Record<any, any>;
   logId: string | null;
-  output: Record<any, any>;
-  status: 'succeeded' | 'failed' | 'running' | 'rejected' | 'retry' | 'error';
+  output?: Record<any, any>;
   startTime: string | null;
-  transitionExecutions: Record<string, Array<string>> | null;
+  status: 'succeeded' | 'failed' | 'running' | 'rejected' | 'retry' | 'error';
+  transitionExecutions?: Record<string, Array<string>> | null;
   workflowId: string;
 };
 
 export type WorkflowExecutionList = {
   executions: Array<Required<WorkflowExecution>>;
   workflowId: string;
-  status?: 'succeeded' | 'failed' | 'running' | 'rejected';
+  status?: Array<'succeeded' | 'failed' | 'running' | 'rejected'>;
   nextToken: string | null;
 };

--- a/packages/las-sdk-node/package.json
+++ b/packages/las-sdk-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lucidtech/las-sdk-node",
-  "version": "13.1.1",
+  "version": "14.0.0",
   "author": "Lucidtech AS <hello@lucidtech.ai>",
   "maintainers": [
     "August André Kvernmo <august@lucidtech.ai>",


### PR DESCRIPTION
- Remove `height` and `width` from all `Model`-related types
- Add optional `owner` query parameter to `listModels` method
- Update `Workflow` type with missing fields
- Make some `Workflow` fields optional
- Remove `avatar`, `email`, `name` from all `User`-related types
- Add `status` to `User`
- Add optional `modelId` query parameter to `listPredictions` method
- Add `getProfile` and `updateProfile` methods